### PR TITLE
feature | spring2 | FRB-165 | 시뮬레이터 토픽 네이밍 로직 변경 | 정민석

### DIFF
--- a/service/simulation/SimulatorInterface2.py
+++ b/service/simulation/SimulatorInterface2.py
@@ -137,3 +137,7 @@ class SimulatorInterface2(ABC):
         a, b = (lower - mu) / sigma, (upper - mu) / sigma
         value = truncnorm.rvs(a, b, loc=mu, scale=sigma)
         return round(value, 2)
+
+    def _build_topic(self, zone_id, equip_id, sensor_id, sensor_type):
+        prefix = "zone" if zone_id == equip_id else "equip"
+        return f"sensor/{prefix}/{zone_id}/{equip_id}/{sensor_id}/{sensor_type}"

--- a/service/simulation/TempSimulator.py
+++ b/service/simulation/TempSimulator.py
@@ -35,7 +35,8 @@ class TempSimulator(ContinuousSimulatorMixin, SimulatorInterface2):
         self.shadow_desired_topic_name = f"$aws/things/Sensor/shadow/name/{self.sensor_id}/update/desired"
         
         # 센서 데이터 publish용 토픽
-        self.topic_name = f"sensor/{zone_id}/{equip_id}/{self.sensor_id}/{self.type}"
+        # self.topic_name = f"sensor/{zone_id}/{equip_id}/{self.sensor_id}/{self.type}"
+        self.topic_name = self._build_topic(zone_id, equip_id,self.sensor_id, self.type)
 
         self.target_temperature = None # 초기값 설정(shadow 용)
         

--- a/simulation_cconfig.json
+++ b/simulation_cconfig.json
@@ -5,7 +5,7 @@
             "interval": 0.5,
             "equip_id": "20250507165750-827",
             "zone_id": "20250507165750-827",
-            "simulator": "current",
+            "simulator": "temp",
             "sensor_num": 1
         }
     ]


### PR DESCRIPTION
## 📌 PR 제목
feature | spring2 | FRB-165 | 시뮬레이터 토픽 네이밍 로직 변경 | 정민석

---

## ✨ 변경 사항
- 센서 토픽의 이름의 상위 단에 equip 혹은 zone이 들어가서 전송되도록 로직을 적용했습니다.

---